### PR TITLE
Add Hack the Box to resources page.

### DIFF
--- a/_posts/2015-04-23-resources.md
+++ b/_posts/2015-04-23-resources.md
@@ -16,7 +16,7 @@ get you started!
     * [shell-storm.org](http://shell-storm.org/repo/CTF/)
     * [capture.thefl.ag](http://captf.com)
 * Wargames:
-    * [Over The Wire](http://overthewire.org/wargames/), various types of wargames.
+    * [Over The Wire](https://overthewire.org/wargames/), various types of wargames.
         * Bandit: &nbsp;Introduction to the Shell (useful even to those experienced with a Unux shell)
         * Leviathan: &nbsp;Introduction
         * Krypton: &nbsp;Cryptography
@@ -35,7 +35,7 @@ get you started!
     * [Hacker.org](http://hacker.org)
     * [hackthebox.eu](https://www.hackthebox.eu/), hack into living machines seeking user & root privileges
 * Cryptography:
-    * [Cryptopals](http://cryptopals.com/), a no-knowledge-necessary site with cryptographic challenges, similar to the well-known [Euler projects](https://projecteuler.net/)
+    * [Cryptopals](https://cryptopals.com/), a no-knowledge-necessary site with cryptographic challenges, similar to the well-known [Euler projects](https://projecteuler.net/)
     * [Khan Academy's Cryptography Series](https://www.khanacademy.org/computing/computer-science/cryptography), a video-lecture series for beginning cryptography.
     * [Learn Cryptography](http://learncryptography.com/), a site to teach you cryptography from the ground up.
 * Bug Bounties / Code Auditing:

--- a/_posts/2015-04-23-resources.md
+++ b/_posts/2015-04-23-resources.md
@@ -33,6 +33,7 @@ get you started!
     * [pwnable.kr](http://pwnable.kr/)
     * [Smash The Stack](http://smashthestack.org/)
     * [Hacker.org](http://hacker.org)
+    * [hackthebox.eu](https://www.hackthebox.eu/), hack into living machines seeking user & root privileges
 * Cryptography:
     * [Cryptopals](http://cryptopals.com/), a no-knowledge-necessary site with cryptographic challenges, similar to the well-known [Euler projects](https://projecteuler.net/)
     * [Khan Academy's Cryptography Series](https://www.khanacademy.org/computing/computer-science/cryptography), a video-lecture series for beginning cryptography.

--- a/about/index.html
+++ b/about/index.html
@@ -4,7 +4,7 @@ layout: default
 <section class='page gray'>
     <h1 class='title'>About us</h1>
     <p>The OSU Security Club was founded in September, 2014 by Daniel Reichert, and is guided
-by <a href="http://web.engr.oregonstate.edu/~rosulekm/">Dr. Mike Rosulek</a>.  
+by <a href="https://web.engr.oregonstate.edu/~rosulekm/">Dr. Mike Rosulek</a>.
 We focus on gaining hands-on experience with vulnerabilities and 
 attacks at both system and networking levels, and getting involved in the security community. 
 There's no experience or knowledge required, only an interest in learning more about


### PR DESCRIPTION
This just adds https://hackthebox.eu to the resources (part of #12 ).

I also tweaked some links to use HTTPS. This is security club, after all. (The HTTP links left untouched either don't support TLS or redirect the user.)